### PR TITLE
Make mapreduce abort datastore-missing tasks much earlier APP-20934

### DIFF
--- a/tasks_test.go
+++ b/tasks_test.go
@@ -153,3 +153,23 @@ func (mrt *MapreduceTests) TestWaitForStageCompletion(c *ck.C) {
 	c.Assert(err, ck.NotNil)
 	taskMock.AssertExpectations(c)
 }
+
+func (mrt *MapreduceTests) TestGetTaskMissing(c *ck.C) {
+	ds := appwrap.NewLocalDatastore(false, nil)
+	key := ds.NewKey(TaskEntity, "", 12345, nil)
+
+	before := time.Now()
+	_, err := getTask(ds, key)
+	c.Assert(err, ck.Equals, appwrap.ErrNoSuchEntity)
+	c.Assert(time.Since(before) < time.Second, ck.IsTrue) // should be zero delay; give plenty of margin for automated tests
+}
+
+func (mrt *MapreduceTests) TestGetJobMissing(c *ck.C) {
+	ds := appwrap.NewLocalDatastore(false, nil)
+	key := ds.NewKey(JobEntity, "", 12345, nil)
+
+	before := time.Now()
+	_, err := getJob(ds, key)
+	c.Assert(err, ck.Equals, appwrap.ErrNoSuchEntity)
+	c.Assert(time.Since(before) < time.Second, ck.IsTrue) // should be zero delay; give plenty of margin for automated tests
+}


### PR DESCRIPTION
https://pendo-io.atlassian.net/browse/APP-20934

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pendo-io/mapreduce/14)
<!-- Reviewable:end -->
