### PR TITLE
Use ampersands in query strings

### DIFF
--- a/map.go
+++ b/map.go
@@ -72,7 +72,7 @@ func mapMonitorTask(c context.Context, ds appwrap.Datastore, pipeline MapReduceP
 
 	for shard := range job.WriterNames {
 		if shards := storageNames[shard]; len(shards) > 0 {
-			url := fmt.Sprintf("%s/reduce?taskKey=%s;shard=%d;writer=%s",
+			url := fmt.Sprintf("%s/reduce?taskKey=%s&shard=%d&writer=%s",
 				job.UrlPrefix, taskKeys[len(tasks)].Encode(), shard, url.QueryEscape(job.WriterNames[shard]))
 
 			shardJson, _ := json.Marshal(shards)
@@ -95,7 +95,7 @@ func mapMonitorTask(c context.Context, ds appwrap.Datastore, pipeline MapReduceP
 	// so we'll just start a single task with no inputs
 	if len(tasks) == 0 {
 		log.Infof("no results from maps -- starting noop reduce task")
-		url := fmt.Sprintf("%s/reduce?taskKey=%s;shard=%d;writer=%s",
+		url := fmt.Sprintf("%s/reduce?taskKey=%s&shard=%d&writer=%s",
 			job.UrlPrefix, taskKeys[len(tasks)].Encode(), 0, url.QueryEscape(job.WriterNames[0]))
 
 		tasks = append(tasks, JobTask{

--- a/mapreduce.go
+++ b/mapreduce.go
@@ -160,7 +160,7 @@ func Run(c context.Context, ds appwrap.Datastore, job MapReduceJob, log appwrap.
 	tasks := make([]JobTask, len(readerNames))
 
 	for i, readerName := range readerNames {
-		url := fmt.Sprintf("%s/map?taskKey=%s;reader=%s;shards=%d",
+		url := fmt.Sprintf("%s/map?taskKey=%s&reader=%s&shards=%d",
 			job.UrlPrefix, taskKeys[i].Encode(), readerName,
 			reducerCount)
 

--- a/reduce.go
+++ b/reduce.go
@@ -45,7 +45,7 @@ func reduceMonitorTask(c context.Context, ds appwrap.Datastore, pipeline MapRedu
 
 	log.Infof("reduce complete status for job %d: %s", appwrap.KeyIntID(jobKey), job.Stage)
 	if job.OnCompleteUrl != "" {
-		successUrl := fmt.Sprintf("%s?status=%s;id=%d", job.OnCompleteUrl, TaskStatusDone, appwrap.KeyIntID(jobKey))
+		successUrl := fmt.Sprintf("%s?status=%s&id=%d", job.OnCompleteUrl, TaskStatusDone, appwrap.KeyIntID(jobKey))
 		log.Infof("posting complete status to url %s", successUrl)
 		pipeline.PostStatus(c, successUrl, log)
 	}

--- a/tasks.go
+++ b/tasks.go
@@ -518,7 +518,7 @@ func jobFailed(c context.Context, ds appwrap.Datastore, taskIntf TaskInterface, 
 	prevJob, _ := markJobFailed(c, ds, jobKey, log) // this might mark it failed again. whatever.
 
 	if prevJob.OnCompleteUrl != "" {
-		taskIntf.PostStatus(c, fmt.Sprintf("%s?status=error;error=%s;id=%d", prevJob.OnCompleteUrl,
+		taskIntf.PostStatus(c, fmt.Sprintf("%s?status=error&error=%s&id=%d", prevJob.OnCompleteUrl,
 			url.QueryEscape(err.Error()), appwrap.KeyIntID(jobKey)), log)
 	}
 


### PR DESCRIPTION
Semicolons are not supported in Go >= 1.17

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pendo-io/mapreduce/20)
<!-- Reviewable:end -->
